### PR TITLE
Added code of conduct page and link to it in footer

### DIFF
--- a/_includes/layouts/code-of-conduct.njk
+++ b/_includes/layouts/code-of-conduct.njk
@@ -1,0 +1,17 @@
+{% extends 'layouts/base.njk' %}
+
+{# Intro content #}
+{% set introHeading = title %}
+
+{% block content %}
+  <main id="main-content" tabindex="-1">
+    <article class="[ post ] [ h-entry ]">
+      {% include "partials/components/intro.njk" %}
+      <div class="[ post__body ] [ inner-wrapper ] [ leading-loose pad-top-900 pad-bottom-900 text-500 ] [ sf-flow ] [ e-content ]">
+        {{ content | safe }}
+      </div>
+    </article>
+  </main>
+{% endblock %}
+
+{{ content | safe }}

--- a/_includes/partials/global/site-foot.njk
+++ b/_includes/partials/global/site-foot.njk
@@ -17,7 +17,7 @@
     </div>
     {% if site.showThemeCredit %}
       <p class="[ site-foot__credit ] [ pad-top-900 ]">
-        Built with ♡ in ATX.
+        Built with ♡ in ATX. | <a href="/code-of-conduct">2022 Code of Conduct</a>
       </p>
     {% endif %}
   </div>

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/danurbanowicz/eleventy-netlify-boilerplate",
   "devDependencies": {
-    "@11ty/eleventy": "^1.0.0",
+    "@11ty/eleventy": "^1.0.1",
     "@mightyplow/eleventy-plugin-cache-buster": "^1.1.3",
     "luxon": "^2.3.0",
     "markdown-it": "^12.3.2",

--- a/pages/code-of-conduct.md
+++ b/pages/code-of-conduct.md
@@ -1,0 +1,109 @@
+---
+title: "Code of Conduct"
+permalink: "/code-of-conduct/index.html"
+layout: "layouts/code-of-conduct.njk"
+tags:
+  - media
+---
+
+## La Murga de Austin Code of Conduct / Código de Conducta de La Murga de Austin
+
+In order to be considered an active member, La Murga de Austin requests that all Murga members agree to our Code of Conduct:
+
+### Code of Conduct / Código de Conducta
+In Austin FC’s inaugural season, La Murga de Austin set a gold standard for what a Major League Soccer supporters section can achieve through intense passion, commitment, songs and chants. And just as our instruments and voices represent the spirit of our club and community, La Murga sets a similar high standard of sportsmanship and respect when it comes to our treatment of one another, our fans, and even fans of our opponents. Racism, sexism, homophobia, transphobia, discrimination, threats and violence will not be tolerated within our membership. This is our standard at home and away, at watch parties, online, and as individuals when we are representing La Murga in the community.
+
+---
+
+Durante la temporada inaugural de Austin FC, La Murga de Austin estableció un estándar de oro para lo que una sección de seguidores de la MLS puede lograr a través de una intensa pasión, compromiso, canciones y porras. Y así como nuestros instrumentos y voces representan el espíritu de nuestro club y comunidad, La Murga establece un alto estándar similar de deporte y respeto cuando se trata de nuestro trato mutuo, seguidores de nuestro equipo y de nuestros rivales. El racismo, el sexismo, la homofobia, la transfobia, la discriminación, las amenazas y la violencia no serán tolerados entre nuestra membresía. Este es nuestro estándar en nuestro estadio y en otros estadios, en fiestas para ver otros juegos cuando nuestro equipo juega fuera de casa, en las plataformas de internet y cómo individuos cuando representamos a La Murga en la comunidad.
+
+### Becoming a Member / Como puedes ser considerado miembro de La Murga de Austin
+La Murga de Austin requires that you must attend at least 3 practices and 1 home game or away watch party within 6 months before you are eligible to become a member. You also must agree to and abide by the tenets of this Code of Conduct.
+
+Section Leads will determine the line up for performers & instruments for each game. In addition, each Lead will inform new members when they are ready to 1) bring an instrument into the stadium or murga performance and 2) when they are clear to perform at La Murga events.
+
+---
+
+La Murga de Austin requiere que asistas al menos a 3 prácticas y 1 partido en casa o una fiesta para ver el juego cuando el equipo juega fuera de casa dentro de 6 meses antes de ser elegible para convertirte en miembro. También debes aceptar y cumplir con las regulaciones de este Código de Conducta.
+
+Los líderes de cada sección determinarán la alineación de los músicos, capos e instrumentos para cada juego. Además, cada Líder informará a los nuevos miembros cuando estén listos para 1) traer un instrumento al estadio o una fiesta para ver el equipo cuando juegan fuera de casa con La Murga y 2) cuándo estén listos para participar como músico o capo en los eventos de La Murga.
+
+### Maintaining Your Membership / Cómo mantener tu membresía
+Members must participate in La Murga de Austin events in order to continue to be considered an active member. This includes:
+- Participation in at least 3 practices and 1 home game or away watch party every 6 months
+- Maintaining a current RSVP status to La Murga events listed in Gig-o-matic (even if you cannot attend and your RSVP is ‘no’)
+
+---
+
+Los miembros deben participar en los eventos de La Murga de Austin para continuar siendo considerados miembros activos. Esto incluye:
+
+- Participar en al menos 3 prácticas y 1 partido en casa o fiesta de partido fuera de casa cada 6 meses
+- Mantener un estado de reservación para los eventos de La Murga enlistados en Gig-O-Matic (aunque no puede asistir y su respuesta a la reservación es  un “No”)
+
+### Conduct / Conducta
+In the interest of sportsmanship and out of respect for others, members of La Murga de Austin should conduct themselves in accordance with the Stadium Code of Conduct both at home and away. Members should also comply with the MLS Code of Conduct.
+
+Behavior that will not be tolerated and may result in suspension of membership:
+- Disclosing any information that is confidential or proprietary to La Murga
+- Mistreatment, damage or theft of La Murga instruments, flags or other property
+- Leading, encouraging or participating in discriminatory chants
+- Throwing objects onto the field (home or away)
+- Using racial slurs, hate speech or other disrespectful language in person or online
+- Engaging in excessively drunken or disorderly behavior at La Murga events
+- Making unwelcome sexual advances or sexually harassing others in person or online
+- Causing property damage at our home stadium or away
+- Reselling tickets in the supporters section without explicitly informing the buyer of the ticket location and expectations, or reselling supporters section tickets above face value or without explaining expectations for the section
+
+---
+
+Con el interés del espíritu deportivo y por respeto a los demás, los miembros de La Murga de Austin deben comportarse de acuerdo con el Código de Conducta del estadio en casa y en estadios cuando somos visitantes. Los miembros también deben cumplir con el Código de conducta de la MLS.
+
+El comportamiento que no será tolerado y puede resultar en la suspensión de la membresía incluye:
+
+- Revelar información que sea confidencial o propiedad de La Murga de Austin
+- Maltrato, daño o robo de instrumentos, banderas u otra propiedad de La Murga de Austin
+- Dirigir, alentar o participar en cantos o porras discriminatorias
+- Lanzar objetos al campo (en casa o de visitante en otro estadio)
+- Usar insultos racistas, comentarios de odio u otro lenguaje que le falte el respeto a otros en persona o por medios de internet 
+- Involucrarse en exceso de ebriedad o conducta desordenada en los eventos de La Murga
+- Hacer avances sexuales no deseados o acosar sexualmente a otros en persona o por medio de medios de internet
+- Causar daños a la propiedad en nuestro estadio lo cuando estemos de visitantes en otros estadios
+- Vender boletos de juegos en casa en la sección de seguidores sin informar explícitamente al comprador de la ubicación y las expectativas de las entradas, vender boletos de juegos en casa por más que el valor original o sin explicarle las expectativas de la sección.
+
+### Media Guidelines / Reglas de medios de La Murga de Austin
+It is encouraged to share La Murga’s content directly from La Murga social media platforms instead of screen grabs. When sharing La Murga content directly, please be sure to credit photographers out of respect for their art and talent.
+
+Be respectful when posting about La Murga, especially when you tag La Murga in your posts.
+
+Get approval from Social Media Lead when engaging with media and speaking on behalf of the organization, or if you would like to use any La Murga content for personal use.
+
+---
+
+Se recomienda compartir el contenido de La Murga de Austin directamente desde las plataformas de redes sociales de La Murga en lugar de capturas de pantalla. Al compartir contenido de La Murga directamente, asegúrese de dar crédito a los fotógrafos por respeto a su arte y talento.
+
+Tener respeto total cuando publiques sobre La Murga, especialmente cuando etiquetes a La Murga de Austin en sus publicaciones.
+
+Obtén la aprobación del líder de plataformas de medios sociales cuando interactúes con los medios de televisión/periódicos y hables en nombre de la organización, o si deseas utilizar cualquier contenido de La Murga de Austin para tu uso personal.
+
+### Code of Conduct Violations / Violaciones del Código de Conducta
+Anyone violating this Code of Conduct is subject to disciplinary action which may include:
+
+- Minor/First time violations will be given a verbal warning
+- Repeat violations, racist or sexist chants, unwanted sexual advances or harassment, or grossly inappropriate behavior on social media will result in a formal warning
+- Two formal warnings issued within a 6-month period or extremely inappropriate behavior will lead to immediate disciplinary action including either temporary suspension or permanent expulsion from La Murga de Austin
+- Inappropriate behavior during a match may result in immediate removal from the supporters section and/or stadium, followed by a review of the incident by La Murga’s Leadership Team
+
+All members are subject to these standards. The members of La Murga’s Leadership Team may be held to a higher standard. La Murga’s Leadership Team (excepting any offenders) will oversee the discipline process.
+
+---
+
+Cualquier persona que viole este Código de conducta estará sujeto a medidas disciplinarias que pueden incluir:
+
+- Las infracciones menores/primeras veces recibirán una advertencia verbal
+- Las infracciones repetidas, los canciones con contenido racista o sexistas, las insinuaciones o el acoso sexual no deseados o el comportamiento extremadamente inapropiado en las redes sociales darán lugar a una advertencia formal.
+- Dos advertencias formales emitidas dentro de un período de 6 meses o un comportamiento extremadamente inapropiado dará lugar a una acción disciplinaria inmediata, incluida la suspensión temporal o la expulsión permanente de La Murga de Austin.
+- El comportamiento inapropiado durante un partido puede resultar en la expulsión inmediata de la sección de aficionados y/o del estadio, seguido de una revisión del incidente por parte del Equipo Directivo de La Murga.
+
+Todos los miembros están sujetos a estas normas. Los miembros del Equipo de Liderazgo de La Murga de Austin pueden tener un estándar más alto. El Equipo de Liderazgo de La Murga (a excepción de los infractores) supervisará el proceso disciplinario.
+
+*Rev. Feb 12, 2022*


### PR DESCRIPTION
I took out all the form fields and mentions of "Membership Form" from the CoC we use this year: https://docs.google.com/forms/d/e/1FAIpQLSfU6KRY8B99CLw4_pMM8tq1gsi7aAbZhAmAw1SP5-9gWo6yqA/viewform. The purpose of adding this is for transparency, though I don't think it's important enough to put in the main nav. I stuck a link to it in the footer

Basically, I made the page contain these parts of the current CoC:
![screencapture-docs-google-forms-d-e-1FAIpQLSfU6KRY8B99CLw4-pMM8tq1gsi7aAbZhAmAw1SP5-9gWo6yqA-viewform-2022-06-17-15_06_41](https://user-images.githubusercontent.com/32335652/174401154-2628d1d8-3517-4436-a88b-ff7439c9caab.png)
.