### PR TITLE
Update donate link

### DIFF
--- a/_data/navigation.json
+++ b/_data/navigation.json
@@ -22,7 +22,7 @@
     },
     {
       "text": "Donate",
-      "url": "https://www.losverdesatx.org/checkout/donate?donatePageId=5f8f0bb6c927da4104704b82",
+      "url": "http://donate.lamurgadeaustin.org/",
       "external": true
     }
   ]


### PR DESCRIPTION
Small change that updates or Donate nav link from a Los Verdes page to a LMdA Paypal page under a new subdomain I set up with Namescheap, our domain name host.